### PR TITLE
fix: Prevent scrolling widget from crashing browser

### DIFF
--- a/public/js/jquery.wolfnetScrollingItems.src.js
+++ b/public/js/jquery.wolfnetScrollingItems.src.js
@@ -87,11 +87,11 @@ if (typeof jQuery != 'undefined') {
          *
          * @return null
          */
-        var ensureThereAreEnoughItems = function(target)
+        var ensureThereAreEnoughItems = function(target, containerWidth)
         {
             var $target = $(target);
             var data = getData(target);
-            var containerWidth = data.$itemContainer.innerWidth();
+            containerWidth = containerWidth || data.$itemContainer.innerWidth();
             var $items = getItems(target);
 
             if (
@@ -101,7 +101,7 @@ if (typeof jQuery != 'undefined') {
 				containerWidth >= (($items.length * data.itemWidth) / 2)
 			) {
                	$items.clone().appendTo(data.$itemContainer);
-               	ensureThereAreEnoughItems(target);
+               	ensureThereAreEnoughItems(target, containerWidth);
             }
 
         };


### PR DESCRIPTION
If a site is using the scrolling widget within a container that is not constrained by width, the
widget now only uses the initial width of the container as reference when determining enough items
have been added to the DOM

[@21931271](https://wolfnet.attask-ondemand.com/issue/view?ID=21931271)