### PR TITLE
feat: Disable scrolling thumbnails on Classic skin

### DIFF
--- a/src/Views.php
+++ b/src/Views.php
@@ -515,7 +515,8 @@ class Wolfnet_Views
 
     private function parseTemplate($template, array $vars = array())
     {
-        $vars['widgetThemeClass'] = 'wolfnet-theme-' . $this->getWidgetTheme();
+        $vars['widgetThemeName'] = $this->getWidgetTheme();
+        $vars['widgetThemeClass'] = 'wolfnet-theme-' . $vars['widgetThemeName'];
 
         extract($vars, EXTR_OVERWRITE);
 

--- a/src/template/listingGrid.php
+++ b/src/template/listingGrid.php
@@ -93,11 +93,14 @@ unset($wpMeta['key']);
             });
         };
 
-        $listingGrid.on('wolfnet.updated', setupThumbnailScroller);
 
         setupToolbar();
         setupListingGrid();
-        setupThumbnailScroller();
+
+        <?php if ($widgetThemeName != 'ash') { ?>
+            $listingGrid.on('wolfnet.updated', setupThumbnailScroller);
+            setupThumbnailScroller();
+        <?php } ?>
 
     });
 


### PR DESCRIPTION
This will disable the thumbnail scroller feature from each listing when using the "Classic" (`ash`) widget theme