### PR TITLE
fix: Sanitize array items separately

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -668,7 +668,7 @@ class Wolfnet_Ajax
     public function remoteRouteQuickSearch()
     {
         try {
-            $response = $GLOBALS['wolfnet']->quickSearch->routeQuickSearch(sanitize_text_field($_REQUEST['formData']));
+            $response = $GLOBALS['wolfnet']->quickSearch->routeQuickSearch(array_map('sanitize_text_field', $_REQUEST['formData']));
         } catch (Wolfnet_Exception $e) {
             status_header(500);
 


### PR DESCRIPTION
`sanitize_text_field` may be messing up the data in the `formData` array.
Trying out the `sanitize_text_field` function on each array item instead.

a22086918